### PR TITLE
Fix: add ctrl-a / ctrl-e support for macOS

### DIFF
--- a/edbee-lib/edbee/data/factorykeymap.cpp
+++ b/edbee-lib/edbee/data/factorykeymap.cpp
@@ -25,7 +25,9 @@ void FactoryKeyMap::fill( TextEditorKeyMap* km )
     add( "goto_next_word", "move_to_next_word" );
     add( "goto_prev_word", "move_to_previous_word" );
     add( "goto_bol", "move_to_start_of_line" );
+    add( "goto_bol", "move_to_start_of_block");
     add( "goto_eol", "move_to_end_of_line" );
+    add( "goto_eol", "move_to_end_of_block");
     add( "goto_next_line", "move_to_next_line" );
     add( "goto_prev_line", "move_to_previous_line" );
     add( "goto_bof", "move_to_start_of_document" );

--- a/edbee-lib/edbee/util/mem/debug_allocs.cpp
+++ b/edbee-lib/edbee/util/mem/debug_allocs.cpp
@@ -33,7 +33,7 @@ DebugAllocationList::DebugAllocationList()
     , running_(false)
     , started_(false)
 {
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+#if (QT_VERSION < QT_VERSION_CHECK(5, 14, 0))
     mutex_ = new EdbeeRecursiveMutex( QMutex::Recursive );
 #else
     mutex_ = new EdbeeRecursiveMutex();
@@ -65,7 +65,7 @@ void DebugAllocationList::clear()
 }
 
 
-/// Retuns the mutex for thread-safety
+/// Returns the mutex for thread-safety
 EdbeeRecursiveMutex* DebugAllocationList::mutex()
 {
     return mutex_;

--- a/edbee-lib/edbee/util/mem/debug_allocs.h
+++ b/edbee-lib/edbee/util/mem/debug_allocs.h
@@ -12,7 +12,7 @@
 
 
 
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+#if (QT_VERSION < QT_VERSION_CHECK(5, 14, 0))
     #define EdbeeRecursiveMutex QMutex
 #else
     #define EdbeeRecursiveMutex QRecursiveMutex

--- a/edbee-lib/edbee/views/components/texteditorautocompletecomponent.cpp
+++ b/edbee-lib/edbee/views/components/texteditorautocompletecomponent.cpp
@@ -59,8 +59,6 @@ TextEditorAutoCompleteComponent::TextEditorAutoCompleteComponent(TextEditorContr
 
     listWidgetRef_->setFocus();
 
-    hide();
-
     infoTipRef_ = new FakeToolTip(controllerRef_, this);
 
     QPalette p = listWidgetRef_->palette();


### PR DESCRIPTION
This fixes https://github.com/Mudlet/Mudlet/issues/4582

This might be desirable to port back upstream to https://github.com/edbee/edbee-lib

Issue: on Mac, ctrl-A and ctrl-E did not work to get to beginning / end of line in the edbee editor. 
This is a supported configuration per https://support.apple.com/en-in/102650 and https://doc.qt.io/qt-5/qkeysequence.html

In Qt, this is called StartOfBlock / EndOfBlock, which maps to Apple's support to "move to [start/end] of the line or paragraph". 

Since, afaik, there's no support for "blocks" in Edbee and Qt only has this "Block" support on macOS, I felt that the right thing to do here was map start/end of block to work the same as start/end of line. Tested and working in Mudlet.

