### PR TITLE
Fix autocomplete stealing keyboard focus on Windows

### DIFF
--- a/edbee-lib/edbee/views/components/texteditorautocompletecomponent.cpp
+++ b/edbee-lib/edbee/views/components/texteditorautocompletecomponent.cpp
@@ -323,6 +323,10 @@ void TextEditorAutoCompleteComponent::positionWidgetForCaretOffset(size_t offset
 void TextEditorAutoCompleteComponent::hideEvent(QHideEvent* event)
 {
     infoTipRef_->hide();
+    // Restore focus to the editor when autocomplete is hidden
+    if (editorComponentRef_) {
+        editorComponentRef_->setFocus();
+    }
     event->isAccepted();
 }
 
@@ -353,6 +357,7 @@ bool TextEditorAutoCompleteComponent::eventFilter(QObject *obj, QEvent *event)
             case Qt::Key_Escape:
                 menuRef_->close();
                 canceled_ = true;
+                editorComponentRef_->setFocus();
                 return true; // stop event
 
             case Qt::Key_Enter:
@@ -360,6 +365,7 @@ bool TextEditorAutoCompleteComponent::eventFilter(QObject *obj, QEvent *event)
             case Qt::Key_Tab:
                 if (listWidgetRef_->currentItem() && currentWord_ == listWidgetRef_->currentItem()->text()) { // sends normal enter/return/tab if you've typed a full word
                     menuRef_->close();
+                    editorComponentRef_->setFocus();
                     QApplication::sendEvent(editorComponentRef_, event);
                     return true;
                 } else if (listWidgetRef_->currentItem()) {
@@ -388,6 +394,7 @@ bool TextEditorAutoCompleteComponent::eventFilter(QObject *obj, QEvent *event)
 
         // default operation is to hide and continue the event
         menuRef_->close();
+        editorComponentRef_->setFocus();
         QApplication::sendEvent(editorComponentRef_, event);
         return true;
 


### PR DESCRIPTION
Fixes the autocomplete popup stealing keyboard focus and preventing further typing after it appears.

## Problem

The autocomplete popup calls `listWidgetRef_->setFocus()` when shown (line 431), which steals keyboard focus from the editor. When the popup closes (Enter, Tab, Escape, or other keys), focus was never restored to the editor component, preventing further typing.

This is the root cause of [Mudlet/Mudlet#5310](https://github.com/Mudlet/Mudlet/issues/5310).

## Fix

Restore focus to `editorComponentRef_` in three places:

1. **`hideEvent()`** - Catch-all: whenever the autocomplete popup is hidden for any reason, restore focus to the editor
2. **Escape key handler** - Immediate restoration when user cancels autocomplete
3. **Enter/Tab full word match & default key handlers** - Restore focus when autocomplete closes after key handling

## Testing

The issue was reported on Windows 10 (Mudlet 4.11.2). The fix applies focus restoration in `hideEvent()` which is called when the popup menu closes, ensuring focus returns to the editor regardless of how the popup was dismissed.