### PR TITLE
Fix autocomplete popup key event filtering

### DIFF
--- a/edbee-lib/edbee/views/components/texteditorautocompletecomponent.cpp
+++ b/edbee-lib/edbee/views/components/texteditorautocompletecomponent.cpp
@@ -336,7 +336,7 @@ bool TextEditorAutoCompleteComponent::eventFilter(QObject *obj, QEvent *event)
         return QObject::eventFilter(obj, event);
     }
 
-    if(obj == listWidgetRef_ && event->type() == QEvent::KeyPress) {
+    if ((obj == listWidgetRef_ || obj == menuRef_) && event->type() == QEvent::KeyPress) {
         QKeyEvent* key = static_cast<QKeyEvent*>(event);
 
         // text keys are allowed


### PR DESCRIPTION
## Summary

Fixes a small autocomplete event filtering edge case where key presses may be delivered to the autocomplete popup menu instead of the list widget.

The autocomplete event filter is installed on both `menuRef_` and `listWidgetRef_`, but previously only handled `QEvent::KeyPress` when the event source was `listWidgetRef_`. This change handles key presses from either object using the same existing logic.

## Why

This is intended to address Mudlet/Mudlet#5310, where autocomplete can steal focus and prevent further typing on Windows.

## Change

- Handle `QEvent::KeyPress` when `obj == listWidgetRef_ || obj == menuRef_`.
- Preserve the existing behavior for typed characters, Escape, Enter/Return/Tab, Backspace, Shift, and navigation keys.
- No autocomplete architecture changes.

## Testing

Not yet manually validated in a full Mudlet Windows build.

Manual Windows validation recommended:
- Trigger autocomplete in Mudlet’s editor.
- Continue typing while the popup is visible.
- Confirm typed characters continue reaching the editor.
- Confirm Escape closes the popup.
- Confirm arrow keys navigate suggestions.
- Confirm Enter/Return/Tab behavior is unchanged.

Related issue: Mudlet/Mudlet#5310